### PR TITLE
Allow navigation to and between activities in the heatmap

### DIFF
--- a/src/app/pages/circular-heatmap/circular-heatmap.component.html
+++ b/src/app/pages/circular-heatmap/circular-heatmap.component.html
@@ -106,7 +106,9 @@
                     <b>Dependencies</b>
                   </mat-panel-title>
                 </mat-expansion-panel-header>
-                <app-dependency-graph [activityName]="showActivityDetails?.name || ''">
+                <app-dependency-graph
+                  [activityName]="showActivityDetails?.name || ''"
+                  (activityClicked)="onDependencyClicked($event)">
                 </app-dependency-graph>
               </mat-expansion-panel>
 
@@ -248,9 +250,7 @@
               (closed)="onPanelClosed(activity)">
               <mat-expansion-panel-header>
                 <mat-panel-title>
-                  <button
-                    class="title-button"
-                    (click)="openActivityDetails(showActivityCard.dimension, activity['name'])">
+                  <button class="title-button" (click)="openActivityDetails(activity['uuid'])">
                     {{ activity['name'] }}
                   </button>
                 </mat-panel-title>

--- a/src/app/pages/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/pages/circular-heatmap/circular-heatmap.component.ts
@@ -2,7 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { equalArray } from 'src/app/util/util';
 import { LoaderService } from 'src/app/service/loader/data-loader.service';
 import * as d3 from 'd3';
-import { Router } from '@angular/router';
+import { Router, ActivatedRoute } from '@angular/router';
+import { Location } from '@angular/common';
 import { MatChip } from '@angular/material/chips';
 import * as md from 'markdown-it';
 import {
@@ -56,6 +57,9 @@ export class CircularHeatmapComponent implements OnInit {
     private loader: LoaderService,
     private sectorService: SectorService,
     private themeService: ThemeService,
+    private router: Router,
+    private route: ActivatedRoute,
+    private location: Location,
     public modal: ModalMessageComponent
   ) {
     this.theme = this.themeService.getTheme();
@@ -110,6 +114,9 @@ export class CircularHeatmapComponent implements OnInit {
           // For now, just draw the sectors (no activities yet)
           this.loadCircularHeatMap('#chart', this.allSectors, this.dimensionLabels, this.maxLevel);
           console.log(`${perfNow()}: Page loaded: Circular Heatmap`);
+
+          // Check if there's a URL fragment and open the corresponding activity
+          this.checkUrlFragmentForActivity();
         })
         .catch(err => {
           this.displayMessage(new DialogInfo(err.message, 'An error occurred'));
@@ -130,6 +137,15 @@ export class CircularHeatmapComponent implements OnInit {
       };
 
       this.reColorHeatmap(); // repaint segments with new theme
+    });
+  }
+
+  checkUrlFragmentForActivity() {
+    // Check if there's a URL fragment that might be an activity UUID
+    this.route.fragment.subscribe(fragment => {
+      if (fragment && this.dataStore) {
+        this.navigateToActivityByUuid(fragment);
+      }
     });
   }
 
@@ -235,6 +251,14 @@ export class CircularHeatmapComponent implements OnInit {
 
   getSectorProgress(sector: Sector): number {
     return this.sectorService.getSectorProgress(sector.activities);
+  }
+
+  onDependencyClicked(activityName: string) {
+    console.log(`${perfNow()}: Heat: Dependency clicked: '${activityName}'`);
+    const activity = this.dataStore?.activityStore?.getActivityByName(activityName);
+    if (activity?.uuid) {
+      this.navigateToActivityByUuid(activity.uuid);
+    }
   }
 
   loadCircularHeatMap(
@@ -540,38 +564,65 @@ export class CircularHeatmapComponent implements OnInit {
     console.log(`${perfNow()}: Heat: Card Panel closed: '${activity.name}'`);
   }
 
-  openActivityDetails(dimension: string, activityName: string) {
+  openActivityDetails(uuid: string) {
     // Find the activity in the selected sector
-    console.log(`${perfNow()}: Heat: Open Overlay: '${activityName}'`);
-    if (!this.dataStore) {
-      console.error(`Data store is not initialized. Cannot open activity ${activityName}`);
+    if (!this.dataStore || !this.dataStore.activityStore) {
+      console.error(`Data store is not initialized. Cannot open activity ${uuid}`);
       return;
     }
     if (!this.showActivityCard || !this.showActivityCard.activities) {
       this.showOverlay = true;
       return;
     }
-    const activity = this.showActivityCard.activities.find(
-      (a: any) => a.activityName === activityName || a.name === activityName
-    );
+
+    const activity: Activity = this.dataStore.activityStore.getActivityByUuid(uuid);
     if (!activity) {
       this.showOverlay = true;
       return;
     }
+
     // Prepare navigationExtras and details
     /* eslint-disable */
+    console.log(`${perfNow()}: Heat: Open Overlay: '${activity.name}'`);
     this.showActivityDetails = activity;
     this.KnowledgeLabel = this.dataStore.getMetaString('knowledgeLabels', activity.difficultyOfImplementation.knowledge);
     this.TimeLabel = this.dataStore.getMetaString('labels', activity.difficultyOfImplementation.time);
     this.ResourceLabel = this.dataStore.getMetaString('labels', activity.difficultyOfImplementation.resources);
     this.UsefulnessLabel = this.dataStore.getMetaString('labels', activity.usefulness);
     this.showOverlay = true;
+
+    // Update URL with activity UUID as fragment
+    if (activity.uuid) {
+      const url = this.router.createUrlTree([], { fragment: activity.uuid }).toString();
+      this.location.go(url);
+    }
     /* eslint-enable */
+  }
+
+  navigateToActivityByUuid(uuid: string) {
+    console.log(`${perfNow()}: Heat: Attempting to open activity with UUID: ${uuid}`);
+    if (!this.dataStore || !this.dataStore.activityStore) {
+      console.error('Data store is not initialized. Cannot open activity by UUID');
+      return;
+    }
+    const activity: Activity = this.dataStore.activityStore.getActivityByUuid(uuid);
+    const sector = this.allSectors.find(s => s.activities.some(a => a.uuid === uuid));
+    if (activity && sector) {
+      this.selectedSector = sector;
+      this.showActivityCard = sector;
+      this.openActivityDetails(activity.uuid);
+    } else {
+      // Only close the overlay, do not update the URL
+      this.showOverlay = false;
+      console.warn(`Heat: Activity with UUID ${uuid} not found.`);
+    }
   }
 
   closeOverlay() {
     this.showOverlay = false;
-    // console.log(`${perfNow()}: Heat: Close Overlay:  '${this.old_activityDetails.name}'`);
+    // Clear the URL fragment when closing overlay
+    const url = this.router.createUrlTree([]).toString();
+    this.location.go(url);
   }
 
   toggleFilters() {

--- a/src/app/pages/circular-heatmap/circular-heatmap.component.ts
+++ b/src/app/pages/circular-heatmap/circular-heatmap.component.ts
@@ -593,8 +593,11 @@ export class CircularHeatmapComponent implements OnInit {
 
     // Update URL with activity UUID as fragment
     if (activity.uuid) {
-      const url = this.router.createUrlTree([], { fragment: activity.uuid }).toString();
-      this.location.go(url);
+      this.router.navigate([], {
+        relativeTo: this.route,
+        fragment: activity.uuid,
+        queryParamsHandling: 'preserve'
+      });      
     }
     /* eslint-enable */
   }
@@ -619,10 +622,9 @@ export class CircularHeatmapComponent implements OnInit {
   }
 
   closeOverlay() {
-    this.showOverlay = false;
     // Clear the URL fragment when closing overlay
-    const url = this.router.createUrlTree([]).toString();
-    this.location.go(url);
+    this.router.navigate([], { relativeTo: this.route, fragment: undefined, queryParamsHandling: 'preserve' });
+    this.showOverlay = false;
   }
 
   toggleFilters() {

--- a/src/assets/Markdown Files/TODO-v4.md
+++ b/src/assets/Markdown Files/TODO-v4.md
@@ -20,7 +20,6 @@
 - Teams: Bug: Editing name, pushes the item last
 - Teams: Allow editing dates for progress stages
 ### Heatmap:
-- Heatmap: Add #uuid to URL, and allow navigation on clicks in dependencies
 - Heatmap: Fix: asterisk marks when modified
   - ViewController needs to know about changes vs temp storage
 - Heatmap: Bug: Clicking on grey sector leaves cursor on that sector
@@ -69,6 +68,7 @@
 - Meta.yaml: Allow admins to customize the terms 'Team' and 'Group' (e.g. to 'App' and 'Portfolio')
 
 # Done
+- Heatmap: Add #uuid to URL, and allow navigation on clicks in dependencies
 - Dependency: Make connecting nodes clickable for navigation
 - Dependency: Handle dependsOn uuid, not just name
 - Matrix: Dependency graph: Render in center of page


### PR DESCRIPTION
By adding the '#{uuid}' in the url, one can now link to a specific activity in the heatmap, and also navigate between the activities using the dependency tree